### PR TITLE
fix: ダッシュボード「自分が担当のタスク」が表示されない不具合を修正

### DIFF
--- a/app/src/DashboardView.jsx
+++ b/app/src/DashboardView.jsx
@@ -73,13 +73,16 @@ export function DashboardView({ user }) {
     return savedSettings ? JSON.parse(savedSettings) : defaultSettings;
   });
 
+  const [currentUserDisplayName, setCurrentUserDisplayName] = useState(null);
+
   useEffect(() => {
     Promise.all([
       axios.get(`${API_URL}/GetTasks`),
       axios.get(`${API_URL}/GetAllUsers`),
       axios.get(`${API_URL}/GetCategories`),
       axios.get(`${API_URL}/GetAutomationRules`),
-    ]).then(([tasksRes, usersRes, categoriesRes, automationRes]) => {
+      axios.get(`${API_URL}/GetUserProfile`).catch(() => ({ data: null })),
+    ]).then(([tasksRes, usersRes, categoriesRes, automationRes, profileRes]) => {
       const normalized = normalizeTasks(tasksRes.data);
       setAllTasks(normalized);
 
@@ -91,6 +94,10 @@ export function DashboardView({ user }) {
 
       const automationData = Array.isArray(automationRes.data) ? automationRes.data : [];
       setAutomationRules(automationData);
+
+      if (profileRes.data?.displayName) {
+        setCurrentUserDisplayName(profileRes.data.displayName);
+      }
     });
   }, []);
 
@@ -252,8 +259,9 @@ export function DashboardView({ user }) {
 
   const myTasks = useMemo(() => {
     if (!user || !user.userDetails) return [];
-    return allTasks.filter((task) => Array.isArray(task.assignees) && task.assignees.includes(user.userDetails));
-  }, [allTasks, user]);
+    const myName = currentUserDisplayName || user.userDetails;
+    return allTasks.filter((task) => Array.isArray(task.assignees) && task.assignees.includes(myName));
+  }, [allTasks, user, currentUserDisplayName]);
 
   const upcomingTasks = useMemo(() => {
     const today = startOfToday();


### PR DESCRIPTION
myTasks フィルターで user.userDetails（認証メールアドレス）と
task.assignees（表示名）を比較していたため、プロフィール設定で
表示名を変更したユーザーのタスクが表示されなかった。

GetUserProfile API で現在ユーザーの displayName を取得し、
それを使ってフィルタリングするよう修正。

https://claude.ai/code/session_01PxYBwxd6fS3aaX2z4qKS9y